### PR TITLE
Feature/improve asset deployment pipeline

### DIFF
--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -162,12 +162,14 @@ const readFileAndDeploy = (bucketNames, bucketPath, localFilePath, gitInfo) => {
 
   // TODO send source maps to Honeybadger (but maybe just the ones we deploy)
 
-  // The default content-type provided by s3 if none is specified.
+  // This is an explicit call out to the default content-type header value used by s3.
   let contentType = "application/octet-stream";
+  // TODO: Add additional content types for all filetypes to be uploaded. text/css is the
+  // only requirement to get the assets working.
   if (ext === ".css") {
     contentType = "text/css";
   }
-
+  
   fs.readFile(localFilePath, (err, data) => {
     if (err) {
       throw err;
@@ -189,7 +191,6 @@ const readFileAndDeploy = (bucketNames, bucketPath, localFilePath, gitInfo) => {
         ContentType: contentType,
       },(err) => {
         if (err) {
-          console.log("this is the error message", err)
           throw err;
         }
         console.log(`Successfully deployed ${localFilePath} to S3 bucket ${bucketName} ${remoteFilePath}`);
@@ -417,7 +418,6 @@ const sendReleaseMessage = (environment, asset) => {
 
 program
   .command('configure <gitCommitSha> <gitBranch>')
-  .description('creates a gurgler.json config file from which the build and deploy process can pull the desired git commit hash and git branch')
   .action((gitCommitSha, gitBranch) => {
     const hash = crypto.createHash('sha256');
     const raw = `${gitCommitSha}|${gitBranch}`;
@@ -438,7 +438,7 @@ program
       if (err) {
         throw err
       }
-      console.log(`gurgler configuration completed successfully; see output at ${filepath}\n`);
+      console.log(`gurgler successfully configured; see ${filepath}\n`);
     })
   });
 
@@ -550,6 +550,7 @@ program
   .option("-e, --environment <environment>", "environment to deploy to")
   .option("-c, --commit <gitSha>", "the git sha (commit) of the asset to deploy")
   .action((cmdObj) => {
+
 
     let environment;
     let asset;

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -418,6 +418,7 @@ const sendReleaseMessage = (environment, asset) => {
 
 program
   .command('configure <gitCommitSha> <gitBranch>')
+  .description('configures a gurgler.json in the root of the project to be referenced by the build and deployment pipeline')
   .action((gitCommitSha, gitBranch) => {
     const hash = crypto.createHash('sha256');
     const raw = `${gitCommitSha}|${gitBranch}`;

--- a/gurgler.js
+++ b/gurgler.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+
+const publicPath = () => {
+  const data = fs.readFileSync("gurgler.json");
+  return JSON.parse(data).publicPath;
+}
+
+module.exports.publicPath = publicPath;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gurgler",
   "version": "1.0.2",
   "description": "A deployment tool.",
-  "main": "index.js",
+  "main": "gurgler.js",
   "repository": "git@github.com:DripEmail/gurgler.git",
   "author": "Jachin Rupe <jachin.rupe@drip.com>",
   "license": "MIT",


### PR DESCRIPTION
This is a small piece of overall discussion we had last week. Hoping to merge this if there's no opposition to the approach and then put up a fresh PR for [ui-components #82](https://github.com/DripEmail/ui-components/pull/82).

### Overview

This is a follow-up to [ui-components #82](https://github.com/DripEmail/ui-components/pull/82). It introduces two minor and one major change. The minor changes are required for us to correctly resolve references to our css and fonts. The major change or at least a variation of it is also required. **The result of these changes means assets are stored under a directory with the checksum rather than having the checksum in each filename.**

Minor:
* Set the content-type of css files uploaded to S3 to be `text/css`.
* Use the file extension of the source file when uploading to S3.

Major:
* Use a `gurgler.json` file to track the git hash and branch throughout the build and deployment process. This is described in detail below and is the proposed replacement to the [previously discussed](https://github.com/DripEmail/ui-components/pull/82#issue-333099402) requirement to include a script in each repo to find and replace all asset references in the minified style bundle before passing the files on to `gurgler`.

### Problem

When assets are built via `webpack` they will often require a `publicPath` key in the `webpack fileloader` config which specifies the path used to reference other assets within the same file. So for example, `a.css` might need to reference `b.woff` as `assets/asdf.b.woff` in order to upload our assets to S3 without breaking the link between them. Since `gurgler` modifies the filepaths after the `webpack` build process is complete, these links are inherently broken unless we can provide webpack with the knowledge of what the resulting filepaths will be.

One solution is to write a script for each repo using gurgler to find and replace all inter-asset references, updating them with the correct filepaths prior to deploying to S3. A proof of this approach was done in [ui-components #82](https://github.com/DripEmail/ui-components/pull/82). However, there are a few downsides to this, namely an increased opportunity for error, the potential need to copy and paste the script to additional repositories, and duplicate code in the script to what gurgler is already doing.

### Solution

Repositories wishing to deploy assets via `gurgler` should install and configure it as is [currently recommended](https://github.com/DripEmail/gurgler/blob/master/README.md). `gurgler` maintains its CLI usage but adds a function to `require` by the webpack config. Prior to the webpack build process, run the `gurgler configure <gitCommitSha> <gitCommitBranch>` CLI command to build a `gurgler.json` file in the root of the project.

```
gurgler configure asdfasdf some_branch
```

A `gurgler.json` is now available in the project root.

```json
{
  "raw": "asdfasdf|some_branch",
  "sha": "238f44f6e7b76256ac881d2c62de03777f99bed37c79a9434070dd257884a60d",
  "publicPath": "assets/238f44f6e7b76256ac881d2c62de03777f99bed37c79a9434070dd257884a60d/"
}
```

A `gurgler.json` file is a description of everything gurgler will add to the uploaded filepaths upon deployment to s3.

* `raw` is the metadata added to the s3 asset.
* `sha` is the hashed version of `raw`.
* `publicPath` is the `publicPath` used to prefix each filename when in S3. It is a combination of the `bucketPath` given in the `gurgler config` within `package.json` and  the hash of `raw`.

As long as the `gurgler configure` command is run prior to the `webpack` build process, we can now make use of `gurgler.publicPath` to read the `gurgler.json` file and tell webpack how we will reference the assets once uploaded to S3.

```javascript
const gurgler = require("gurgler");

...

const publicPath = gurgler.publicPath();

...

{
   loader: "file-loader",
    options: {
      name: "[name].[ext]"
        publicPath: publicPath
      }
   }
}
```

This will give us the correct output in the build output directory where all files are non-prefixed with the public path (`gurgler deploy` hasn't touched them yet) but the internal references from one file to the other have the correct public path.

As a side note, we can write a very simple script to combine the `gurgler configure` and `webpack` build commands into a single command.

Now that we have the assets built and a `gurgler.json` describing how those files are referenced by one another, we can run `gurgler deploy` without any arguments since we already know what git commit sha and git branch the files belong to. Internally, `gurgler` just references the `gurgler.json` and appends the `publicPath` to each file prior to uploading to s3.

### Usage
```
npm run configure asdfasdf some_branch
npm run build
npm run deploy
```
As mentioned,  we can combine the first two commands relatively easy to be run in a single build command resulting in something like the following.

```
npm run build asdfasdf some_branch
npm run deploy
```

The release process has not been touched and is as currently described in the README.