### PR TITLE
Feature/improve asset deployment pipeline

### DIFF
--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -162,12 +162,14 @@ const readFileAndDeploy = (bucketNames, bucketPath, localFilePath, gitInfo) => {
 
   // TODO send source maps to Honeybadger (but maybe just the ones we deploy)
 
-  // The default content-type provided by s3 if none is specified.
+  // This is an explicit call out to the default content-type header value used by s3.
   let contentType = "application/octet-stream";
+  // TODO: Add additional content types for all filetypes to be uploaded. text/css is the
+  // only requirement to get the assets working.
   if (ext === ".css") {
     contentType = "text/css";
   }
-
+  
   fs.readFile(localFilePath, (err, data) => {
     if (err) {
       throw err;
@@ -189,7 +191,6 @@ const readFileAndDeploy = (bucketNames, bucketPath, localFilePath, gitInfo) => {
         ContentType: contentType,
       },(err) => {
         if (err) {
-          console.log("this is the error message", err)
           throw err;
         }
         console.log(`Successfully deployed ${localFilePath} to S3 bucket ${bucketName} ${remoteFilePath}`);
@@ -417,7 +418,6 @@ const sendReleaseMessage = (environment, asset) => {
 
 program
   .command('configure <gitCommitSha> <gitBranch>')
-  .description('creates a gurgler.json config file from which the build and deploy process can pull the desired git commit hash and git branch')
   .action((gitCommitSha, gitBranch) => {
     const hash = crypto.createHash('sha256');
     const raw = `${gitCommitSha}|${gitBranch}`;
@@ -438,7 +438,7 @@ program
       if (err) {
         throw err
       }
-      console.log(`gurgler configuration completed successfully; see output at ${filepath}\n`);
+      console.log(`gurgler successfully configured; see ${filepath}\n`);
     })
   });
 
@@ -550,6 +550,7 @@ program
   .option("-e, --environment <environment>", "environment to deploy to")
   .option("-c, --commit <gitSha>", "the git sha (commit) of the asset to deploy")
   .action((cmdObj) => {
+
 
     let environment;
     let asset;

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -425,12 +425,12 @@ program
   
     hash.update(raw);
     const sha = hash.digest('hex');
-    const publicPath = `${bucketPath}/${sha}/`
+    const prefix = bucketPath + "/" + sha
 
     const data = JSON.stringify({
       raw,
       sha,
-      publicPath,
+      prefix,
     }, null, 2);
 
     const filepath = "gurgler.json"
@@ -451,9 +451,9 @@ program
       if (err) {
         throw err;
       }
-      const { raw: gitInfo, publicPath } = JSON.parse(data)
+      const { raw: gitInfo, prefix } = JSON.parse(data)
       localFilePaths.forEach(localFilePath => {
-        readFileAndDeploy( bucketNames, publicPath, localFilePath, gitInfo);
+        readFileAndDeploy( bucketNames, prefix, localFilePath, gitInfo);
       });
     });
   });
@@ -551,7 +551,6 @@ program
   .option("-e, --environment <environment>", "environment to deploy to")
   .option("-c, --commit <gitSha>", "the git sha (commit) of the asset to deploy")
   .action((cmdObj) => {
-
 
     let environment;
     let asset;

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -418,6 +418,7 @@ const sendReleaseMessage = (environment, asset) => {
 
 program
   .command('configure <gitCommitSha> <gitBranch>')
+  .description('configures a gurgler.json in the root of the project to be referenced by the build and deployment pipeline')
   .action((gitCommitSha, gitBranch) => {
     const hash = crypto.createHash('sha256');
     const raw = `${gitCommitSha}|${gitBranch}`;

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -568,9 +568,25 @@ const confirmRelease = (environment, gurgler) => {
   return inquirer.prompt([{
     type: 'confirm',
     name: 'confirmation',
-    message: `Do you want to release ${packageName} git[${gurgler.gitShaDigest}] checksum[${gurgler.checksumDigest}] to ${environment.key}?`,
+    message: `Do you want to release ${packageName} git[${gurgler.gitShaDigest}] 
+              checksum[${gurgler.checksumDigest}] to ${environment.key}?`,
     default: false
-  }]);
+  }]).then(answers => {
+    if (
+      answers.confirmation && 
+      environment.masterOnly && 
+      gurgler.gitBranch !== 'master'
+    ) {
+      return inquirer.prompt([{
+        type: 'confirm',
+        name: 'confirmation',
+        message: `Warning: You are attempting to release a non-master branch[${gurgler.gitBranch}]
+                  to a master-only environment[${environment.serverEnvironment}]. Do you wish to 
+                  proceed?`,
+      }])
+    }
+    return answers;
+  })
 };
 
 program

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -514,7 +514,7 @@ const determineEnvironment = (cmdObj, environments) => {
 const determineGurglerToRelease = (cmdObj, environment) => {
   const bucketName = _.get(bucketNames, environment.serverEnvironment);
   if (!bucketName) {
-    console.error(`The server environment "${environment.serverEnvironment}" does not exist, the environment must match a bucketName key`)
+    console.error(`\nThe server environment "${environment.serverEnvironment}" does not exist, the environment must match a bucketNames key in package.json\n`)
     process.exit(1);
   }
 

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -219,7 +219,7 @@ const readFileAndDeploy = (bucketNames, bucketPath, localFilePath, gitInfo) => {
       throw err;
     }
     
-    const { name, ext } = path.parse(localFilePath);
+    const { base, name, ext } = path.parse(localFilePath);
     const contentType = getContentType(ext);
 
     let remoteFilePath;
@@ -227,7 +227,7 @@ const readFileAndDeploy = (bucketNames, bucketPath, localFilePath, gitInfo) => {
     // objects under that prefix. This means the release process can pull down at once all common
     // prefixes and any metadata related to all objects under each unique prefix.
     if (name === "gurgler.json") {
-      remoteFilePath = `${bucketPath}.${name}`
+      remoteFilePath = `${bucketPath}.${base}`
     } else {
       remoteFilePath = path.join(bucketPath, name+ext);
     }

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -568,8 +568,7 @@ const confirmRelease = (environment, gurgler) => {
   return inquirer.prompt([{
     type: 'confirm',
     name: 'confirmation',
-    message: `Do you want to release ${packageName} git[${gurgler.gitShaDigest}] 
-              checksum[${gurgler.checksumDigest}] to ${environment.key}?`,
+    message: `Do you want to release ${packageName} git[${gurgler.gitShaDigest}] checksum[${gurgler.checksumDigest}] to ${environment.key}?`,
     default: false
   }]).then(answers => {
     if (
@@ -580,9 +579,7 @@ const confirmRelease = (environment, gurgler) => {
       return inquirer.prompt([{
         type: 'confirm',
         name: 'confirmation',
-        message: `Warning: You are attempting to release a non-master branch[${gurgler.gitBranch}]
-                  to a master-only environment[${environment.serverEnvironment}]. Do you wish to 
-                  proceed?`,
+        message: `Warning: You are attempting to release a non-master branch[${gurgler.gitBranch}] to a master-only environment[${environment.serverEnvironment}]. Do you wish to proceed?`,
       }])
     }
     return answers;

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -114,6 +114,8 @@ const getContentType = (ext) => {
     contentType = "application/json"
   } else if (ext === ".html") {
     contentType = "text/html"
+  } else if (ext ===  ".js") {
+    contentType = "application/javascript"
   }
   return contentType;
 }

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -509,8 +509,8 @@ const determineEnvironment = (cmdObj, environments) => {
   }
 };
 
-const determineGurglerToRelease = (cmdObj, enviornment) => {
-  const bucketName = _.get(bucketNames, enviornment.serverEnvironment);
+const determineGurglerToRelease = (cmdObj, environment) => {
+  const bucketName = _.get(bucketNames, environment.serverEnvironment);
   if (!bucketName) {
     console.error(`The server environment "${environment.serverEnvironment}" does not exist, the environment must match a bucketName key`)
     process.exit(1);

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -511,6 +511,10 @@ const determineEnvironment = (cmdObj, environments) => {
 
 const determineGurglerToRelease = (cmdObj, enviornment) => {
   const bucketName = _.get(bucketNames, enviornment.serverEnvironment);
+  if (!bucketName) {
+    console.error(`The server environment "${environment.serverEnvironment}" does not exist, the environment must match a bucketName key`)
+    process.exit(1);
+  }
 
   return getGurglers(bucketName, bucketPath)
     .then(gurglers => {

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -226,10 +226,10 @@ const readFileAndDeploy = (bucketNames, bucketPath, localFilePath, gitInfo) => {
     // We want the gurgler.json to live in the same hierarchical tier as the prefix to all other
     // objects under that prefix. This means the release process can pull down at once all common
     // prefixes and any metadata related to all objects under each unique prefix.
-    if (name === "gurgler.json") {
+    if (base === "gurgler.json") {
       remoteFilePath = `${bucketPath}.${base}`
     } else {
-      remoteFilePath = path.join(bucketPath, name+ext);
+      remoteFilePath = path.join(bucketPath, base);
     }
 
     _.forEach(bucketNames, (bucketName) => {

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -503,7 +503,7 @@ program
   .description('sends a new asset (at a particular commit on a particular branch) to the S3 bucket')
   .action(() => {
     const gurglerPath = "gurgler.json";
-    fs.readFile(filepath, (err, data) => {
+    fs.readFile(gurglerPath, (err, data) => {
       if (err) {
         throw err;
       }

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -529,7 +529,7 @@ const determineGurglerToRelease = (cmdObj, environment) => {
       return Promise.all(gurglers.map(gurgler => addGitInfo(gurgler)));
     })
     .then(gurglers => {
-      if( _.isEmpty(cmdObj.commit)) {
+      if ( _.isEmpty(cmdObj.commit)) {
         return inquirer.prompt([ {
             type: 'list',
             name: 'gurgler',
@@ -539,8 +539,7 @@ const determineGurglerToRelease = (cmdObj, environment) => {
               }
             )
         }])
-      }
-      else {
+      } else {
         return new Promise(((resolve) => {
           if (cmdObj.commit.length < 7) {
             console.error(`The checksum "${cmdObj.commit}" is not long enough, it should be at least 7 characters.`);

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -332,7 +332,7 @@ const addGitSha = (version) => {
         return reject(err);
       }
 
-      const metaData = data.Metadata['git-sha'];
+      const metaData = data.Metadata['git-info'];
       if (metaData !== '' && metaData !== undefined) {
         const parsedMetaData = metaData.split('|');
         version.gitSha = parsedMetaData[0];

--- a/gurgler.js
+++ b/gurgler.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+
+const publicPath = () => {
+  const data = fs.readFileSync("gurgler.json");
+  return JSON.parse(data).publicPath;
+}
+
+module.exports.publicPath = publicPath;

--- a/gurgler.js
+++ b/gurgler.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 
 const publicPath = () => {
   const data = fs.readFileSync("gurgler.json");
-  return JSON.parse(data).publicPath;
+  return JSON.parse(data).prefix + "/";
 }
 
 module.exports.publicPath = publicPath;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gurgler",
   "version": "1.0.2",
   "description": "A deployment tool.",
-  "main": "index.js",
+  "main": "gurgler.js",
   "repository": "git@github.com:DripEmail/gurgler.git",
   "author": "Jachin Rupe <jachin.rupe@drip.com>",
   "license": "MIT",


### PR DESCRIPTION
### Background

This pull request is the culmination of several conversations around the general strategy for building, deploying, and releasing our front-end assets. You can see [ui-components #82](https://github.com/DripEmail/ui-components/pull/82) for some context. This is the follow-up to #3 and includes the full deployment pipeline from build to release. 

A fairly straight-forward follow-up PR will be required in the `ui-components` repository after this is merged.

### Overview

We want to deploy all our assets under a versioned directory/S3 path prefix instead of versioning each asset individually. We also want to be able to inform webpack how our assets will be publicly referenced prior to building them. Otherwise, once built via webpack, any changes to the filenames and/or paths to those files break internal references to other assets.

There are four minor and two major changes. The two major changes are described in detail further down this page.

Minor:

* Avoid the default content type of `application/octet-stream` for most filetypes.
* Preserve file extensions across all file types when uploading to S3.
* Make the Slack webhook optional.
* Warn and require confirmation when attempting to release non-master branches to production or other master-only environments.
* Support deploying directories rather than just individual files (did not remove the `localFilePaths` key nor function).
* Various name changes where it made sense due to the other changes described here.

Major:

* Implement a `gurgler.json` file in the project root to reference critical data required by webpack and deploy and release commands. 
* Upload all assets pertaining to a single version under a single common key prefix. A file representing each version is stored at the same hierarchy and is used to query all available versions without retrieving every object in the bucket.

### Details

`gurgler` should continue to be installed and configured as [currently described](https://github.com/DripEmail/gurgler/blob/master/README.md). The only exceptions are the now optional use of a Slack webhook to send a release message to a particular Slack channel and the introduction of the `masterOnly` key which will be described later. In `package.json` under the gurgler key, the omission of **all** Slack-related keys (`slackWebHookUrl`, `sslackUsername`, `slackEmoji`, `githubRepoUrl`) will disable the webhook.

There is now an additional CLI command to the previous `gurgler deploy` and `gurgler release`. Use `gurgler configure <gitCommitSha> <gitBranch>` to generate a `gurgler.json` file in the project root.

```json
{
  "gitInfo": "asdfasdfasdf|some_branch",
  "checksum": "238f44f6e7b76256ac881d2c62de03777f99bed37c79a9434070dd257884a60d",
  "prefix": "assets/238f44f6e7b76256ac881d2c62de03777f99bed37c79a9434070dd257884a60d"
}
```

`checksum` is the SHA-256 hash of `gitInfo` and the unique identifier of this particular versioned group of assets.

We can now require the `publicPath` function to use in our webpack configuration. This will tell webpack what the assets' public path will be once gurgler has deployed them.

```javascript
const gurgler = require("gurgler")
...
{
  loader: "file-loader",
    options: {
      name: "[name].[ext]"
      publicPath: gurgler.publicPath()
    }
}
```

When webpack builds the assets the filenames in the output directory won't have changed but the internal references to those files will be prefixed with `publicPath`.

Now we can run `gurgler deploy` without any arguments and `gurgler.json` will let gurgler know under what bucket key prefix to deploy the assets. It is important to note the deploy process will also copy `gurgler.json` and upload it under a sibling key to the common prefix under which all assets are stored. This file acts as a manifest to the release process, allowing us to only pull down a single file for each deployed version instead of every single asset.

```
assets/asdfasdfasdf/styles.css
assets/asdfasdfasdf/font.woff

assets/asdfasdfasdf.gurgler.json
```

When it's time to release a particular version to a particular environment, the options remain the same as before. You can either provide the git commit sha and environment to `gurgler release` or run the command without arguments and answer the prompts. Either way, you will be asked to confirm your release and an attempt to release to a master-only environment a version which corresponds to a non-master branch will result in a warning and additional confirmation prompt.

As a reminder, `gurgler release` will update parameter store to set the corresponding key to the specified deployed version.

You can specify any environment as a master-only environment with the `masterOnly` key.

```json
"environments": [
  {
    "key": "production",
    "ssmKey": "/test/assets/test-prod/checksum",
    "serverEnvironment": "production",
    "masterOnly": true,
    "label": "production",
  }
]
```

<img width="1053" alt="Screen Shot 2019-11-08 at 2 07 56 AM" src="https://user-images.githubusercontent.com/28585418/68463789-a2880200-01cc-11ea-89d4-793f759a0537.png">

### Additional Notes

* Add the `gurgler.json` to the project's `.gitignore`
* CircleCI can be utilized to build and deploy (or release if you really wanted to)
* Combine the `gurgler configure` and webpack build processes into a single command

`gurgler` now accepts glob pattens to describe which directories/files to upload. It looks like this in the config:

```json
"globs": [
  {
    "pattern": "./dist/*",
    "ignore": [
        "./*/drip-base-styles.bundle.js",
        "./*/manifest.json"
    ]
  }
],
```

I'm open to better naming conventions.

### Example Usage

```
yarn build asdfasdf some_branch
yarn deploy
yarn release
```