### PR TITLE
Fs 238/cross account lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Options:
 
 ### Version 2
 
-There currently exist two deployment options while we phase into complete use of version 2. A version 1 deployment appends a file's checksum to the filename itself, allowing releases of individual files. Version 2 deploys all assets under a single common S3 bucket prefix which is the hash of both the git commit and branch to which those assets pertain.
+There currently exist two deployment options while we phase into complete use of version 2. A version 1 deployment appends a file's checksum to the filename itself, allowing releases of individual files. Version 2 deploys all assets under a single common S3 bucket prefix which is the hash of both the git commit and branch to which those assets pertain. As of version 2.1, releases made under the v2 workflow (as described below) are made possible via a cross-account lambda and not direct access to parameter store.
 
 Version 2 also introduces a few new configuration changes and overall deployment workflow:
 

--- a/bin/v2.js
+++ b/bin/v2.js
@@ -411,7 +411,7 @@ const release = (environment, version, packageName, slackConfig) => {
     FunctionName: "drip-production-gurgler",
     InvocationType: "RequestResponse",
     Payload: JSON.stringify({
-      parameterName: ssmKey,
+      parameterName: environment.ssmKey,
       parameterValue: version.hash,
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gurgler",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A deployment tool.",
   "main": "gurgler.js",
   "repository": "git@github.com:DripEmail/gurgler.git",


### PR DESCRIPTION
Addresses: [FS-237](https://dripcom.atlassian.net/browse/FS-237) [FS-238](https://dripcom.atlassian.net/browse/FS-238)

https://github.com/DripEmail/gurgler-lambda

## Background

We will be introducing a microservice to handle querying the currently released asset versions for a given environment. To support the staged rollout we need the released versions to be available in both production and tier1-production accounts. We have a cross-account Lambda function (see the above link) which gurgler should call to update parameter store in each account. The monolith can continue referencing parameter store in the production account while the microservice can pull the same values from parameter store in the tier1-production account.

## Changes

Replace direct parameter store access with an invocation of the corresponding AWS Lambda Function.

## Testing

I've referenced this branch in the ui-components repo and updated the version 2 assets via the release v2 command.