### PR TITLE
Bugfix/slack webhook

### DIFF
--- a/bin/v1.js
+++ b/bin/v1.js
@@ -416,7 +416,7 @@ const sendReleaseMessage = (environment, asset, packageName, slackConfig) => {
     const slackChannel = environment.slackChannel;
   
     if (!_.isEmpty(slackConfig.slackWebHookUrl) && !_.isEmpty(slackChannel)) {
-      const webhook = new IncomingWebhook(slackWebHookUrl);
+      const webhook = new IncomingWebhook(slackConfig.slackWebHookUrl);
   
       (async () => {
         await webhook.send({

--- a/bin/v2.js
+++ b/bin/v2.js
@@ -379,7 +379,7 @@ const sendReleaseMessage = (environment, version, packageName, slackConfig) => {
     const slackChannel = environment.slackChannel;
   
     if (!_.isEmpty(slackConfig.slackWebHookUrl) && !_.isEmpty(slackChannel)) {
-      const webhook = new IncomingWebhook(slackWebHookUrl);
+      const webhook = new IncomingWebhook(slackConfig.slackWebHookUrl);
   
       (async () => {
         await webhook.send({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gurgler",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A deployment tool.",
   "main": "gurgler.js",
   "repository": "git@github.com:DripEmail/gurgler.git",


### PR DESCRIPTION
Fix undefined variable. This will restore the slack webhook to post release messages in deploy-staging and deploy-production channels.