### PR TITLE
Fix issue when s3 returns a paginated list

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
 </project>

--- a/bin/v2.mjs
+++ b/bin/v2.mjs
@@ -181,14 +181,14 @@ const getDeployedVersionList = async (bucketName, bucketPath) => {
 
   // Get the first batch.
   const command = new ListObjectsV2Command(input);
-  const response = await client.send(command);
+  let response = await client.send(command);
   allVersions = allVersions.concat(response.Contents);
 
   while (response.IsTruncated) {
     // If there's more get those too
     input.ContinuationToken = response.NextContinuationToken;
-    const command = new ListObjectsV2Command(input);
-    const response = await client.send(command);
+    const innerCommand = new ListObjectsV2Command(input);
+    response = await client.send(innerCommand);
 
     allVersions = allVersions.concat(response.Contents);
   }


### PR DESCRIPTION
If we need to make multiple requests in order to fetch all of the
objects in s3, overwriting the response variable creates a temporal
dead zone (TDZ) and results in an error about trying to access the
variable before initialization.

Also renammed the inner command to avoid shadowing.
