### PR TITLE
Allow gurgler to deploy file in directories

### DIFF
--- a/bin/v2.js
+++ b/bin/v2.js
@@ -1,13 +1,13 @@
-const fs = require('fs');
-const AWS = require('aws-sdk');
-const inquirer = require('inquirer');
-const path = require('path');
-const _ = require('lodash');
-const crypto = require('crypto');
-const {IncomingWebhook} = require('@slack/webhook');
+const fs = require("fs");
+const AWS = require("aws-sdk");
+const inquirer = require("inquirer");
+const path = require("path");
+const _ = require("lodash");
+const crypto = require("crypto");
+const { IncomingWebhook } = require("@slack/webhook");
 const glob = require("glob");
 const utils = require("./utils");
-const {getGitInfo} = require("./git");
+const { getGitInfo } = require("./git");
 
 /**
  * Send the file to S3. All files except gurgler.json are considered assets and will be prefixed with
@@ -22,8 +22,13 @@ const {getGitInfo} = require("./git");
  * @param {Boolean} pretend
  */
 
-const readFileAndDeploy = (bucketNames, prefix, localFilePath, gitInfo, pretend = false) => {
-
+const readFileAndDeploy = (
+  bucketNames,
+  prefix,
+  localFilePath,
+  gitInfo,
+  pretend = false
+) => {
   // TODO upload map file if it exists.
 
   // TODO send source maps to Honeybadger (but maybe just the ones we deploy)
@@ -33,40 +38,46 @@ const readFileAndDeploy = (bucketNames, prefix, localFilePath, gitInfo, pretend 
       throw err;
     }
 
-    const {base, ext} = path.parse(localFilePath);
+    const { base, ext } = path.parse(localFilePath);
     const contentType = utils.getContentType(ext);
 
     let remoteFilePath;
     if (base === "gurgler.json") {
       // prefix.gurgler.json is a sibling to the prefix under which all the assets are keyed.
-      remoteFilePath = `${prefix}.${base}`
+      remoteFilePath = `${prefix}.${base}`;
     } else {
       remoteFilePath = path.join(prefix, base);
     }
 
     _.forEach(bucketNames, (bucketName) => {
       if (pretend) {
-        console.log(`Only pretending to deploy ${localFilePath} to S3 bucket ${bucketName} ${remoteFilePath}`);
+        console.log(
+          `Only pretending to deploy ${localFilePath} to S3 bucket ${bucketName} ${remoteFilePath}`
+        );
       } else {
         const s3 = new AWS.S3({
-          apiVersion: '2006-03-01',
-          params: {Bucket: bucketName}
+          apiVersion: "2006-03-01",
+          params: { Bucket: bucketName },
         });
 
-        s3.upload({
-          Key: remoteFilePath,
-          Body: data,
-          ACL: 'public-read',
-          Metadata: {'git-info': gitInfo},
-          ContentType: contentType,
-        }, (err) => {
-          if (err) {
-            throw err;
+        s3.upload(
+          {
+            Key: remoteFilePath,
+            Body: data,
+            ACL: "public-read",
+            Metadata: { "git-info": gitInfo },
+            ContentType: contentType,
+          },
+          (err) => {
+            if (err) {
+              throw err;
+            }
+            console.log(
+              `Successfully deployed ${localFilePath} to S3 bucket ${bucketName} ${remoteFilePath}`
+            );
           }
-          console.log(`Successfully deployed ${localFilePath} to S3 bucket ${bucketName} ${remoteFilePath}`);
-        });
+        );
       }
-
     });
   });
 };
@@ -79,15 +90,14 @@ const readFileAndDeploy = (bucketNames, prefix, localFilePath, gitInfo, pretend 
  */
 
 const requestCurrentlyReleasedVersions = (environments) => {
-
-  const ssmKeys = environments.map(env => env.ssmKey);
+  const ssmKeys = environments.map((env) => env.ssmKey);
 
   const ssm = new AWS.SSM({
-    apiVersion: '2014-11-06'
+    apiVersion: "2014-11-06",
   });
 
   const params = {
-    Names: ssmKeys
+    Names: ssmKeys,
   };
 
   return new Promise((resolve, reject) => {
@@ -96,11 +106,14 @@ const requestCurrentlyReleasedVersions = (environments) => {
         return reject(err);
       }
 
-      const environmentsWithReleaseData = environments.map(env => {
-        const value = _.find(data.Parameters, v => env.ssmKey === v.Name);
+      const environmentsWithReleaseData = environments.map((env) => {
+        const value = _.find(data.Parameters, (v) => env.ssmKey === v.Name);
 
         env.releasedHash = _.get(value, "Value", "Unreleased!");
-        env.releaseHashShort = env.releasedHash === "Unreleased!" ? "Unreleased!" : utils.shortHash(env.releasedHash)
+        env.releaseHashShort =
+          env.releasedHash === "Unreleased!"
+            ? "Unreleased!"
+            : utils.shortHash(env.releasedHash);
         env.releaseDateStr = _.get(value, "LastModifiedDate");
 
         return env;
@@ -113,29 +126,36 @@ const requestCurrentlyReleasedVersions = (environments) => {
 
 const determineEnvironment = (cmdObj, environments) => {
   if (_.isEmpty(cmdObj.environment)) {
-    return inquirer.prompt([{
-      type: 'list',
-      name: 'environment',
-      message: 'Which environment will receive this release?',
-      choices: environments.map(env => {
-        const label = _.padEnd(env.label, 12);
-        return {
-          name: `${label} ${env.releaseHashShort}`,
-          value: env
-        }
-      })
-    }]);
+    return inquirer.prompt([
+      {
+        type: "list",
+        name: "environment",
+        message: "Which environment will receive this release?",
+        choices: environments.map((env) => {
+          const label = _.padEnd(env.label, 12);
+          return {
+            name: `${label} ${env.releaseHashShort}`,
+            value: env,
+          };
+        }),
+      },
+    ]);
   } else {
-    return new Promise(((resolve) => {
-      const environment = _.find(environments, e => e.key === cmdObj.environment);
+    return new Promise((resolve) => {
+      const environment = _.find(
+        environments,
+        (e) => e.key === cmdObj.environment
+      );
       if (!environment) {
-        const keys = environments.map(e => e.key);
+        const keys = environments.map((e) => e.key);
         const keysStr = _.join(keys, ", ");
-        console.error(`"${cmdObj.environment}" does not appear to be a valid environment. The choices are: ${keysStr}`);
+        console.error(
+          `"${cmdObj.environment}" does not appear to be a valid environment. The choices are: ${keysStr}`
+        );
         process.exit(1);
       }
-      resolve({environment: environment});
-    }))
+      resolve({ environment: environment });
+    });
   }
 };
 
@@ -148,7 +168,7 @@ const determineEnvironment = (cmdObj, environments) => {
 
 const getDeployedVersionList = (bucketName, bucketPath) => {
   const s3 = new AWS.S3({
-    apiVersion: '2006-03-01'
+    apiVersion: "2006-03-01",
   });
 
   return new Promise((resolve, reject) => {
@@ -168,27 +188,29 @@ const getDeployedVersionList = (bucketName, bucketPath) => {
 
       s3.listObjectsV2(opts, (err, data) => {
         if (err) {
-          reject()
+          reject();
         }
 
         const concatenated = allVersions.concat(data.Contents);
 
         // Make sure we're only ever pulling our gurgler.json manifest files.
-        allVersions = _.filter(concatenated, version => {
-          const {base, ext} = path.parse(version.Key);
-          return (ext === ".json" && base.split(".")[1] === "gurgler");
-        })
+        allVersions = _.filter(concatenated, (version) => {
+          const { base, ext } = path.parse(version.Key);
+          return ext === ".json" && base.split(".")[1] === "gurgler";
+        });
 
         if (data.IsTruncated) {
           listAllVersions(data.NextContinuationToken);
         } else {
-          resolve(allVersions.map(version => {
-            return {
-              filepath: version.Key,
-              lastModified: version.LastModified,
-              bucket: bucketName,
-            }
-          }));
+          resolve(
+            allVersions.map((version) => {
+              return {
+                filepath: version.Key,
+                lastModified: version.LastModified,
+                bucket: bucketName,
+              };
+            })
+          );
         }
       });
     };
@@ -207,25 +229,20 @@ const getDeployedVersionList = (bucketName, bucketPath) => {
 const formatAndLimitDeployedVersions = (versions, size) => {
   const returnedVersions = [];
 
-  _.reverse(
-    _.sortBy(
-      versions,
-      ['lastModified']
-    )
-  )
-    .slice(0, size).forEach(version => {
+  _.reverse(_.sortBy(versions, ["lastModified"]))
+    .slice(0, size)
+    .forEach((version) => {
+      const { base, ext } = path.parse(version.filepath);
+      const split = base.split(".");
 
-    const {base, ext} = path.parse(version.filepath);
-    const split = base.split(".");
-
-    // This check is technically not necessary assuming getDeployedVersionList only returns versions
-    // matching this criteria.
-    if (ext === ".json" && split[1] === "gurgler") {
-      version.hash = split[0];
-      version.hashDigest = version.hash.substr(0, 7);
-      returnedVersions.push(version);
-    }
-  });
+      // This check is technically not necessary assuming getDeployedVersionList only returns versions
+      // matching this criteria.
+      if (ext === ".json" && split[1] === "gurgler") {
+        version.hash = split[0];
+        version.hashDigest = version.hash.substr(0, 7);
+        returnedVersions.push(version);
+      }
+    });
 
   return returnedVersions;
 };
@@ -239,31 +256,34 @@ const formatAndLimitDeployedVersions = (versions, size) => {
 
 const addGitSha = (version) => {
   const s3 = new AWS.S3({
-    apiVersion: '2006-03-01'
+    apiVersion: "2006-03-01",
   });
 
   return new Promise((resolve, reject) => {
-    s3.headObject({
-      Bucket: version.bucket,
-      Key: version.filepath
-    }, (err, data) => {
-      if (err) {
-        return reject(err);
-      }
+    s3.headObject(
+      {
+        Bucket: version.bucket,
+        Key: version.filepath,
+      },
+      (err, data) => {
+        if (err) {
+          return reject(err);
+        }
 
-      const metaData = data.Metadata['git-info'];
-      if (metaData !== '' && metaData !== undefined) {
-        const parsedMetaData = metaData.split('|');
-        version.gitSha = parsedMetaData[0];
-        version.gitShaDigest = parsedMetaData[0].substr(0, 7);
-        version.gitBranch = parsedMetaData[1];
+        const metaData = data.Metadata["git-info"];
+        if (metaData !== "" && metaData !== undefined) {
+          const parsedMetaData = metaData.split("|");
+          version.gitSha = parsedMetaData[0];
+          version.gitShaDigest = parsedMetaData[0].substr(0, 7);
+          version.gitBranch = parsedMetaData[1];
+        }
+        return resolve(version);
       }
-      return resolve(version);
-    });
+    );
   });
 };
 
-const  addGitInfo = async (version, packageName) => {
+const addGitInfo = async (version, packageName) => {
   const gitSha = version.gitSha;
 
   const gitInfo = await getGitInfo(gitSha);
@@ -272,66 +292,88 @@ const  addGitInfo = async (version, packageName) => {
   const commitDateStr = gitInfo.get("date").padEnd(16);
   const hashShort = utils.shortHash(version.hash);
   const gitShaShort = utils.shortHash(gitSha);
-  const gitBranch = _.isEmpty(version.gitBranch) ? "" : _.truncate(version.gitBranch, {length: 15});
-  const gitMessage = _.truncate(gitInfo.get("message"), {length: 30}).replace(/(\r\n|\n|\r)/gm, '');
+  const gitBranch = _.isEmpty(version.gitBranch)
+    ? ""
+    : _.truncate(version.gitBranch, { length: 15 });
+  const gitMessage = _.truncate(gitInfo.get("message"), { length: 30 }).replace(
+    /(\r\n|\n|\r)/gm,
+    ""
+  );
   version.displayName = `${commitDateStr} | ${packageName}[${hashShort}] | ${author} | git[${gitShaShort}] | [${gitBranch}] ${gitMessage}`;
   return version;
 };
 
-const determineVersionToRelease = (cmdObj, bucketNames, environment, bucketPath, packageName) => {
+const determineVersionToRelease = (
+  cmdObj,
+  bucketNames,
+  environment,
+  bucketPath,
+  packageName
+) => {
   const bucketName = _.get(bucketNames, environment.serverEnvironment);
   if (!bucketName) {
-    console.error(`The server environment ${environment.serverEnvironment} does not exist.`)
+    console.error(
+      `The server environment ${environment.serverEnvironment} does not exist.`
+    );
     process.exit(1);
   }
 
   return getDeployedVersionList(bucketName, bucketPath)
-    .then(versions => {
+    .then((versions) => {
       return formatAndLimitDeployedVersions(versions, 20); // Only show last 20 versions
     })
-    .then(versions => {
-      return Promise.all(versions.map(version => addGitSha(version)));
+    .then((versions) => {
+      return Promise.all(versions.map((version) => addGitSha(version)));
     })
-    .then(versions => {
-      return Promise.all(versions.map(version => addGitInfo(version, packageName)));
+    .then((versions) => {
+      return Promise.all(
+        versions.map((version) => addGitInfo(version, packageName))
+      );
     })
-    .then(versions => {
+    .then((versions) => {
       if (versions.length === 0) {
-        console.log("\n> There are no currently deployed versions. Run 'gurgler configure <gitCommitSha> <gitBranch>' and `gurgler deploy` and try again.\n");
+        console.log(
+          "\n> There are no currently deployed versions. Run 'gurgler configure <gitCommitSha> <gitBranch>' and `gurgler deploy` and try again.\n"
+        );
         process.exit(0);
       }
       if (_.isEmpty(cmdObj.commit)) {
-        return inquirer.prompt([{
-          type: 'list',
-          name: 'version',
-          message: 'Which deployed version would you like to release?',
-          choices: versions.map(version => {
-              return {name: version.displayName, value: version}
-            }
-          )
-        }])
+        return inquirer.prompt([
+          {
+            type: "list",
+            name: "version",
+            message: "Which deployed version would you like to release?",
+            choices: versions.map((version) => {
+              return { name: version.displayName, value: version };
+            }),
+          },
+        ]);
       } else {
-        return new Promise(((resolve) => {
+        return new Promise((resolve) => {
           if (cmdObj.commit.length < 7) {
-            console.error(`The checksum "${cmdObj.commit}" is not long enough, it should be at least 7 characters.`);
+            console.error(
+              `The checksum "${cmdObj.commit}" is not long enough, it should be at least 7 characters.`
+            );
             process.exit(1);
           }
 
-          const version = _.find(versions, version => {
-            return _.startsWith(version.gitSha, cmdObj.commit)
+          const version = _.find(versions, (version) => {
+            return _.startsWith(version.gitSha, cmdObj.commit);
           });
 
           // TODO If we do not find it in this list of assets, check older assets too.
 
           if (!version) {
-            console.error(`"${cmdObj.commit}" does not appear to be a valid checksum.`);
+            console.error(
+              `"${cmdObj.commit}" does not appear to be a valid checksum.`
+            );
             process.exit(1);
           }
 
-          resolve({version: version});
-        }));
+          resolve({ version: version });
+        });
       }
-    })
+    });
 };
 
 /**
@@ -364,9 +406,9 @@ const sendReleaseMessage = (environment, version, packageName, slackConfig) => {
           username: slackConfig.slackUsername,
           text: slackMessage,
           icon_emoji: slackConfig.slackIconEmoji,
-          channel: slackChannel
-        })
-      })().catch(err => console.error(err));
+          channel: slackChannel,
+        });
+      })().catch((err) => console.error(err));
     }
   }
 
@@ -383,17 +425,27 @@ const sendReleaseMessage = (environment, version, packageName, slackConfig) => {
  * @param {object} slackConfig
  */
 
-const release = (environment, version, lambdaFunctions, packageName, slackConfig) => {
+const release = (
+  environment,
+  version,
+  lambdaFunctions,
+  packageName,
+  slackConfig
+) => {
   const lambda = new AWS.Lambda({
-    apiVersion: '2015-03-31'
+    apiVersion: "2015-03-31",
   });
 
-  if (!_.has(environment, 'serverEnvironment')) {
-    throw new Error(`The server environment for this environment is not set: ${environment.key}`);
+  if (!_.has(environment, "serverEnvironment")) {
+    throw new Error(
+      `The server environment for this environment is not set: ${environment.key}`
+    );
   }
 
   if (!_.has(lambdaFunctions, environment.serverEnvironment)) {
-    throw new Error(`the lambda function for the following enviroment is not set: ${environment.serverEnvironment}`);
+    throw new Error(
+      `the lambda function for the following enviroment is not set: ${environment.serverEnvironment}`
+    );
   }
 
   const functionName = lambdaFunctions[environment.serverEnvironment];
@@ -404,68 +456,84 @@ const release = (environment, version, lambdaFunctions, packageName, slackConfig
     Payload: JSON.stringify({
       parameterName: environment.ssmKey,
       parameterValue: version.hash,
-    })
-  }
+    }),
+  };
 
   lambda.invoke(params, (err, data) => {
     if (err) {
       throw err;
     }
     if (data.StatusCode !== 200) {
-      throw new Error(`unsuccessful lambda invocation; unable to release asset version; got status ${data.StatusCode}`);
+      throw new Error(
+        `unsuccessful lambda invocation; unable to release asset version; got status ${data.StatusCode}`
+      );
     }
     if (data.FunctionError) {
-      throw new Error(`one or more parameter store values could not be updated: ${data.Payload}`);
+      throw new Error(
+        `one or more parameter store values could not be updated: ${data.Payload}`
+      );
     }
     sendReleaseMessage(environment, version, packageName, slackConfig);
   });
 };
 
 const confirmRelease = (environment, version, packageName) => {
-  return inquirer.prompt([{
-    type: 'confirm',
-    name: 'confirmation',
-    message: `Do you want to release ${packageName} git[${version.gitShaDigest}] hash[${version.hashDigest}] to ${environment.key}?`,
-    default: false
-  }]).then(answers => {
-    if (
-      answers.confirmation &&
-      environment.masterOnly &&
-      version.gitBranch !== 'master'
-    ) {
-      return inquirer.prompt([{
-        type: 'confirm',
-        name: 'confirmation',
-        message: `Warning: You are attempting to release a non-master branch[${version.gitBranch}] to a master-only environment[${environment.serverEnvironment}]. Do you wish to proceed?`,
-      }])
-    }
-    return answers;
-  })
+  return inquirer
+    .prompt([
+      {
+        type: "confirm",
+        name: "confirmation",
+        message: `Do you want to release ${packageName} git[${version.gitShaDigest}] hash[${version.hashDigest}] to ${environment.key}?`,
+        default: false,
+      },
+    ])
+    .then((answers) => {
+      if (
+        answers.confirmation &&
+        environment.masterOnly &&
+        version.gitBranch !== "master"
+      ) {
+        return inquirer.prompt([
+          {
+            type: "confirm",
+            name: "confirmation",
+            message: `Warning: You are attempting to release a non-master branch[${version.gitBranch}] to a master-only environment[${environment.serverEnvironment}]. Do you wish to proceed?`,
+          },
+        ]);
+      }
+      return answers;
+    });
 };
 
 const configureCmd = (gurglerPath, bucketPath, commit, branch) => {
-  const hash = crypto.createHash('sha256');
+  const hash = crypto.createHash("sha256");
   const raw = `${commit}|${branch}`;
 
   hash.update(raw);
-  const hashed = hash.digest('hex');
-  const prefix = bucketPath + "/" + hashed
+  const hashed = hash.digest("hex");
+  const prefix = bucketPath + "/" + hashed;
 
-  const data = JSON.stringify({
-    commit,
-    branch,
-    raw,
-    hash: hashed,
-    prefix,
-  }, null, 2);
+  const data = JSON.stringify(
+    {
+      commit,
+      branch,
+      raw,
+      hash: hashed,
+      prefix,
+    },
+    null,
+    2
+  );
 
-  fs.writeFile(gurglerPath, data, err => {
+  fs.writeFile(gurglerPath, data, (err) => {
     if (err) {
-      throw err
+      throw err;
     }
-    console.log(`gurgler successfully configured; the current build info can be found at ${gurglerPath}\n`);
-  })
-}
+    console.log(
+      `gurgler successfully configured; the current build info can be found at ${gurglerPath}\n`
+    );
+  });
+};
 
 /**
  *
@@ -474,59 +542,86 @@ const configureCmd = (gurglerPath, bucketPath, commit, branch) => {
  * @param globs
  * @param pretend {boolean}
  */
-const deployCmd = (bucketNames, gurglerPath, globs, pretend= false) => {
-  fs.readFile(gurglerPath, 'utf-8', (err, data) => {
+const deployCmd = (bucketNames, gurglerPath, globs, pretend = false) => {
+  fs.readFile(gurglerPath, "utf-8", (err, data) => {
     if (err) {
-      if (err.code === 'ENOENT') {
-        console.log("Either gurgler.json has not been built or it has been removed. Run 'gurgler configure <git commit sha> <git branch>' and try again.");
+      if (err.code === "ENOENT") {
+        console.log(
+          "Either gurgler.json has not been built or it has been removed. Run 'gurgler configure <git commit sha> <git branch>' and try again."
+        );
       }
       throw err;
     }
 
     let localFilePaths = [gurglerPath];
 
-    globs.forEach(globb => {
-      localFilePaths = localFilePaths.concat(glob.sync(globb.pattern, {
-        ignore: globb.ignore
-      }))
-    })
+    globs.forEach((globb) => {
+      localFilePaths = localFilePaths.concat(
+        glob.sync(globb.pattern, {
+          ignore: globb.ignore,
+        })
+      );
+    });
 
-    const {prefix, raw} = JSON.parse(data)
+    const { prefix, raw } = JSON.parse(data);
 
-    localFilePaths.forEach(localFilePath => {
-      readFileAndDeploy(bucketNames, prefix, localFilePath, raw, pretend);
+    localFilePaths.forEach((localFilePath) => {
+      if (fs.statSync(localFilePath).isFile()) {
+        // Skip anything that's not a file (like a directory).
+        readFileAndDeploy(bucketNames, prefix, localFilePath, raw, pretend);
+      }
     });
   });
-}
+};
 
-const releaseCmd = (cmdObj, bucketNames, lambdaFunctions, environments, bucketPath, packageName, slackConfig) => {
+const releaseCmd = (
+  cmdObj,
+  bucketNames,
+  lambdaFunctions,
+  environments,
+  bucketPath,
+  packageName,
+  slackConfig
+) => {
   let environment;
   let version;
 
   requestCurrentlyReleasedVersions(environments)
-    .then(environments => {
-      return determineEnvironment(cmdObj, environments)
+    .then((environments) => {
+      return determineEnvironment(cmdObj, environments);
     })
-    .then(answers => {
+    .then((answers) => {
       environment = answers.environment;
-      return determineVersionToRelease(cmdObj, bucketNames, environment, bucketPath, packageName)
+      return determineVersionToRelease(
+        cmdObj,
+        bucketNames,
+        environment,
+        bucketPath,
+        packageName
+      );
     })
-    .then(answers => {
+    .then((answers) => {
       version = answers.version;
       return confirmRelease(environment, version, packageName);
     })
-    .then(answers => {
+    .then((answers) => {
       if (answers.confirmation) {
-        release(environment, version, lambdaFunctions, packageName, slackConfig);
+        release(
+          environment,
+          version,
+          lambdaFunctions,
+          packageName,
+          slackConfig
+        );
       } else {
         console.log("Cancelling release...");
       }
     })
-    .catch(err => console.error(err));
-}
+    .catch((err) => console.error(err));
+};
 
 module.exports = {
   configureCmd,
   deployCmd,
-  releaseCmd
-}
+  releaseCmd,
+};


### PR DESCRIPTION
There was a change I made on the 3.2.2 release, and this is effectively a back port of that.

https://github.com/DripEmail/gurgler/commit/35585ef05b0faa6aa66372aaf4d92637e8e13a2f

eslint also went to town on this file too