### PR TITLE
Fix updated deploy process

### DIFF
--- a/bin/v2.mjs
+++ b/bin/v2.mjs
@@ -282,7 +282,7 @@ const formatAndLimitDeployedVersions = (versions, size) => {
       }
     });
 
-  return returnedVersions;
+  return _.uniqBy(returnedVersions, (v) => v.hashDigest);
 };
 
 /**

--- a/bin/v2.mjs
+++ b/bin/v2.mjs
@@ -186,7 +186,7 @@ const getDeployedVersionList = async (bucketName, bucketPath) => {
   let response = await client.send(command);
   allVersions = allVersions.concat(response.Contents);
 
-  while (response.IsTruncated) {
+  if (response.IsTruncated) {
     // If there's more get those too
     input.ContinuationToken = response.NextContinuationToken;
     const innerCommand = new ListObjectsCommand(input);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2738,9 +2738,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -6409,9 +6409,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "foreground-child": {
       "version": "3.1.1",


### PR DESCRIPTION
Version 3.2.2 wasn't working. In a repo we'd try `npm run release` and it would freeze up after environment selection. 

- replace a `while` with an `if`; gurgler was getting stuck in the `while` and the process would eventually run out of memory.
- dedupe the release list so there's only unique commits to choose from in the list.
- bump follow-redirects from 1.15.3 to 1.15.6 (security update)

Tested locally and I am able to deploy again. This will become version 3.2.3 and alleviate some security alert noise.
