### PR TITLE
Release 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gurgler",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "description": "A deployment tool.",
   "main": "gurgler.js",


### PR DESCRIPTION
- replace a while with an if; gurgler was getting stuck in the while and the process would eventually run out of memory.
- dedupe the release list so there's only unique commits to choose from in the list.
- bump follow-redirects from 1.15.3 to 1.15.6 (security update)

changes visible in this PR: https://github.com/DripEmail/gurgler/pull/53
