### PR TITLE
Change Slack Webhook Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,19 @@ Add a `gurgler` key to your `package.json`. It should look something like this:
         "ssmKey": "/dev/asset-checksum",
         "serverEnvironment": "development",
         "label": "Development",
-        "slackChannel": "#deployments"
+        "slackWebHookUrl": "http://hooks.slack.com/services/Something/Something/Something",
       },
       {
         "key": "production",
         "ssmKey": "/production/asset-checksum",
         "serverEnvironment": "production",
         "label": "Production",
-        "slackChannel": "#deployments"
+        "slackWebHookUrl": "http://hooks.slack.com/services/Something/Something/Something",
       }
     ],
     "localFilePaths": [
       "./dist/my-asset.js"
     ],
-    "slackWebHookUrl": "http://hooks.slack.com/services/Something/Something/Something",
-    "slackUsername": "Something",
-    "slackIconEmoji": ":something:",
     "githubRepoUrl": "https://github.com/User/repo"
     }
 }

--- a/bin/gurgler.js
+++ b/bin/gurgler.js
@@ -29,12 +29,8 @@ const lambdaFunctions = gurglerConfig["lambdaFunctions"];
 const bucketPath = gurglerConfig["bucketPath"];
 const bucketRegion = gurglerConfig["bucketRegion"];
 const globs = gurglerConfig["localFileGlobs"];
-const slackWebHookUrl = gurglerConfig["slackWebHookUrl"];
-const slackUsername = gurglerConfig["slackUsername"];
-const slackIconEmoji = gurglerConfig["slackIconEmoji"];
 const githubRepoUrl = gurglerConfig["githubRepoUrl"];
 
-let slackConfig;
 
 if (_.isEmpty(packageName)) {
   console.error("The package name is not set.");
@@ -59,42 +55,6 @@ if (_.isEmpty(bucketPath)) {
 if (_.isEmpty(bucketRegion)) {
   console.error("The config value bucketRegion is not set.");
   process.exit(1);
-}
-
-// If at least one slack-related key is present in the gurgler config it is assumed Slack should be
-// used and all Slack config values are inspected. The omission of all slack-related keys rather
-// obviously indicates Slack is not intended to be used, and we don"t need to inspect each key.
-if (
-  _.has(gurglerConfig, "slackWebHookUrl") ||
-  _.has(gurglerConfig, "slackUsername") ||
-  _.has(gurglerConfig, "slackIconEmoji")
-) {
-  if (_.isEmpty(slackWebHookUrl)) {
-    console.error("The config value slackWebHookUrl is not set.");
-    process.exit(1);
-  }
-
-  if (_.isEmpty(slackUsername)) {
-    console.error("The config value slackUsername is not set.");
-    process.exit(1);
-  }
-
-  if (_.isEmpty(slackIconEmoji)) {
-    console.error("The config value slackIconEmoji is not set.");
-    process.exit(1);
-  }
-
-  if (_.isEmpty(githubRepoUrl)) {
-    console.error("The config value githubRepoUrl is not set.");
-    process.exit(1);
-  }
-
-  slackConfig = {
-    slackWebHookUrl,
-    slackUsername,
-    slackIconEmoji,
-    githubRepoUrl,
-  };
 }
 
 /**
@@ -203,7 +163,7 @@ program
       environments,
       bucketPath,
       packageName,
-      slackConfig,
+      githubRepoUrl,
     );
   });
 
@@ -222,7 +182,7 @@ program
       bucketRegion,
       bucketPath,
       packageName,
-      slackConfig,
+      githubRepoUrl,
     );
   });
 


### PR DESCRIPTION
Our webhooks broke, and I'm not entirely sure why, but the old way of IncomingWebhooks with slack will eventually be deprecated, so I switched to using SlackApps. 

This means we have to pass Gurgler less information, as the Slack Apps allow posting to a singular channel, using a logo decided by the App. 

UI Components Working (using locally edited gurgler files):

<img width="807" alt="Screenshot 2025-04-03 at 5 13 18 PM" src="https://github.com/user-attachments/assets/aa36cd90-d393-4858-913a-d44993df76c9" />

https://github.com/user-attachments/assets/e91abeab-d7a4-4d63-a72b-8b4b6e6cb0f9


Elm Working:
<img width="872" alt="Screenshot 2025-04-03 at 5 20 23 PM" src="https://github.com/user-attachments/assets/f821f5c2-dbbd-4aae-b541-a6d7e635fcc0" />

https://github.com/user-attachments/assets/0a697956-add4-4712-b0d3-f2227c1b4cd7


^These PRs will follow once a new version of Gurgler is released


