### PR TITLE
Release 3.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gurgler",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gurgler",
-      "version": "3.2.5",
+      "version": "3.2.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.670.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gurgler",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "type": "module",
   "description": "A deployment tool.",
   "main": "gurgler.js",


### PR DESCRIPTION
Security updates.

- Bump form-data from 4.0.0 to 4.0.4: https://github.com/DripEmail/gurgler/pull/64
- Bump axios from 1.7.7 to 1.8.4: https://github.com/DripEmail/gurgler/pull/63
- Bump brace-expansion from 1.1.11 to 1.1.12: https://github.com/DripEmail/gurgler/pull/67
- Update inquirer from 9.2.12 to 12.9.3, remove tmp: https://github.com/DripEmail/gurgler/pull/66

